### PR TITLE
PC-230 Update retention_schema.sql

### DIFF
--- a/scripts/sql/retention_schema.sql
+++ b/scripts/sql/retention_schema.sql
@@ -30,9 +30,9 @@ CREATE TABLE retention_rule (
 CREATE TABLE retention_rule_history (
   `id` int UNSIGNED NOT NULL AUTO_INCREMENT PRIMARY KEY,
   `retention_rule_id` int UNSIGNED NOT NULL,
-  `dataset_name` varchar(256) NOT NULL,
+  `dataset_name` varchar(256) NULL,
   `retention_period_in_days` int UNSIGNED NOT NULL,
-  `data_storage_name` varchar(256) NOT NULL,
+  `data_storage_name` varchar(256) NULL,
   `project_id` varchar(256) NOT NULL,
   `type` enum('global', 'dataset') NOT NULL,
   `version` int UNSIGNED NOT NULL DEFAULT 0,


### PR DESCRIPTION
Changing dataset_name and data_storage_name to be nullable. These fields are not required for global-default rule types.