### PR TITLE
PC-142: Prefix generation utility

### DIFF
--- a/src/main/java/com/google/gcs/sdrs/util/PrefixGeneratorUtility.java
+++ b/src/main/java/com/google/gcs/sdrs/util/PrefixGeneratorUtility.java
@@ -33,22 +33,22 @@ public class PrefixGeneratorUtility {
    * Generate a list of bucket name prefixes within a time interval.
    *
    * @param pattern indicating the base portion of the prefix.
-   * @param mostRecent indicating the time of the most recent prefix to generate (exclusive).
-   * @param leastRecent indicating the time of the least recent prefix to generate. This value must
-   *     be earlier than {@code mostRecent}. There is no guarantee that files older than this value
+   * @param startTime indicating the time of the least recent prefix to generate. This value must
+   *     be earlier than {@code endTime}. There is no guarantee that files older than this value
    *     will not be deleted.
+   * @param endTime indicating the time of the most recent prefix to generate.
    * @return a {@link Collection} of {@link String}s of the form `pattern/period` for every time
-   *     segment within the interval between mostRecent and leastRecent.
+   *     segment within the interval between endTime and startTime.
    */
   public static Collection<String> generateTimePrefixes(
-      String pattern, ZonedDateTime mostRecent, ZonedDateTime leastRecent) {
+      String pattern, ZonedDateTime startTime, ZonedDateTime endTime) {
 
-    if (mostRecent.isBefore(leastRecent)) {
+    if (endTime.isBefore(startTime)) {
       throw new IllegalArgumentException(
-          "mostRecent occurs before leastRecent; try swapping them.");
+          "endTime occurs before startTime; try swapping them.");
     }
 
-    mostRecent = mostRecent.truncatedTo(ChronoUnit.HOURS);
+    endTime = endTime.truncatedTo(ChronoUnit.HOURS);
 
     Collection<String> result = new HashSet<>();
 
@@ -58,14 +58,14 @@ public class PrefixGeneratorUtility {
     formatters.put(ChronoUnit.DAYS, DateTimeFormatter.ofPattern("yyyy/MM/dd"));
     formatters.put(ChronoUnit.HOURS, DateTimeFormatter.ofPattern("yyyy/MM/dd/HH"));
 
-    ZonedDateTime currentTime = ZonedDateTime.from(leastRecent);
-    while (currentTime.isBefore(mostRecent)) {
+    ZonedDateTime currentTime = ZonedDateTime.from(startTime);
+    while (currentTime.isBefore(endTime)) {
       ChronoUnit increment;
-      if (!mostRecent.isBefore(currentTime.plus(1, ChronoUnit.YEARS))) {
+      if (!endTime.isBefore(currentTime.plus(1, ChronoUnit.YEARS))) {
         increment = ChronoUnit.YEARS;
-      } else if (!mostRecent.isBefore(currentTime.plus(1, ChronoUnit.MONTHS))) {
+      } else if (!endTime.isBefore(currentTime.plus(1, ChronoUnit.MONTHS))) {
         increment = ChronoUnit.MONTHS;
-      } else if (!mostRecent.isBefore(currentTime.plus(1, ChronoUnit.DAYS))) {
+      } else if (!endTime.isBefore(currentTime.plus(1, ChronoUnit.DAYS))) {
         increment = ChronoUnit.DAYS;
       } else {
         increment = ChronoUnit.HOURS;

--- a/src/test/java/com/google/gcs/sdrs/util/PrefixGeneratorUtilityTest.java
+++ b/src/test/java/com/google/gcs/sdrs/util/PrefixGeneratorUtilityTest.java
@@ -39,7 +39,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     List<String> resultList = new ArrayList<>(result);
     assertTrue(resultList.get(0).startsWith("pattern/example/"));
@@ -51,7 +51,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(1, result.size());
   }
@@ -62,7 +62,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(1, result.size());
     List<String> resultList = new ArrayList<>(result);
@@ -75,7 +75,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 2, 0, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(1, result.size());
     List<String> resultList = new ArrayList<>(result);
@@ -88,7 +88,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 2, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(1, result.size());
     List<String> resultList = new ArrayList<>(result);
@@ -101,7 +101,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(1, result.size());
     List<String> resultList = new ArrayList<>(result);
@@ -114,7 +114,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2020, 2, 2, 1, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(4, result.size());
     assertTrue(result.contains("test/2019"));
@@ -129,7 +129,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2018, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2020, 3, 3, 2, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(8, result.size());
     assertTrue(result.contains("test/2018"));
@@ -148,7 +148,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2018, 3, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2020, 3, 3, 2, 0, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     // Not all of 2018 is between the two dates, but all of 2018 is to be deleted because there is
     // no requirement to preserve old values.
@@ -161,7 +161,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(2));
 
-    PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
   }
 
   @Test
@@ -170,7 +170,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.ofHours(-12));
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 1, 1, 0, 0, 0, ZoneOffset.ofHours(-12));
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(1, result.size());
     List<String> resultList = new ArrayList<>(result);
@@ -183,7 +183,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2020, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
 
-    PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
   }
 
   @Test
@@ -192,7 +192,7 @@ public class PrefixGeneratorUtilityTest {
     ZonedDateTime time1 = ZonedDateTime.of(2019, 1, 1, 0, 0, 0, 0, ZoneOffset.UTC);
     ZonedDateTime time2 = ZonedDateTime.of(2019, 1, 1, 1, 30, 0, 0, ZoneOffset.UTC);
 
-    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time2, time1);
+    Collection<String> result = PrefixGeneratorUtility.generateTimePrefixes(pattern, time1, time2);
 
     assertEquals(1, result.size());
     List<String> resultList = new ArrayList<>(result);


### PR DESCRIPTION
This utility class is intended to generate a collection of strings corresponding to the time range between 2 points in time.

They generally follow the form of `prefix/yyyy/MM/dd/hh`.
The hours/days/months will drop off if the range contains all possible values for that interval.

For example, between January 31 10:00 PM to Feb 1 2:30 AM you'd get this output:
`pattern/2019/01/31`, `pattern/2019/02/1/01`, `pattern/2019/02/1/02`
The more recent time value is a hard stop that should never be included in the output.
But note that the full day of Jan 31st is included in the output collection, even though only 10-11 PM and 11-12 PM are technically within the range.