### PR TITLE
PC-297 Create Unique Composite Key Mod Script

### DIFF
--- a/scripts/sql/mods/00_add_retention_rule_business_key.sql
+++ b/scripts/sql/mods/00_add_retention_rule_business_key.sql
@@ -6,16 +6,30 @@ DELIMITER //
 
 CREATE PROCEDURE modify_sdrs_add_rule_composite_key ( )
 BEGIN
+  DECLARE oldIndexExists INT;
   DECLARE indexExists INT;
-  SELECT COUNT(*) INTO indexExists
+
+  -- Drop the old 3 value index if it still exists
+  SELECT COUNT(*) INTO oldIndexExists
   FROM INFORMATION_SCHEMA.STATISTICS
   WHERE table_schema=DATABASE()
     AND table_name='retention_rule'
     AND index_name='unique_dataset_storage_project';
 
   IF indexExists = 0 THEN
+    DROP INDEX unique_dataset_storage_project on retention_rule;
+  END IF;
+
+  -- Create new 2 value index if it doesn't exist
+  SELECT COUNT(*) INTO indexExists
+  FROM INFORMATION_SCHEMA.STATISTICS
+  WHERE table_schema=DATABASE()
+    AND table_name='retention_rule'
+    AND index_name='unique_storage_project';
+
+  IF indexExists = 0 THEN
     ALTER TABLE retention_rule
-      ADD UNIQUE KEY `unique_dataset_storage_project` (`dataset_name`, `data_storage_name`, `project_id`);
+    ADD UNIQUE KEY `unique_storage_project` (`data_storage_name`, `project_id`);
   END IF;
 END//
 

--- a/scripts/sql/retention_schema.sql
+++ b/scripts/sql/retention_schema.sql
@@ -23,7 +23,7 @@ CREATE TABLE retention_rule (
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `updated_at` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
   `user` varchar(256) NOT NULL,
-  UNIQUE KEY `unique_dataset_storage_project` (`dataset_name`, `data_storage_name`, `project_id`),
+  UNIQUE KEY `unique_storage_project` (`data_storage_name`, `project_id`),
   INDEX `retention_rule_dataset_name` (`dataset_name`),
   INDEX `retention_rule_is_active` (`is_active`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8;


### PR DESCRIPTION
Adding a safe, repeatable mod script to add the retention rule composite key to the retention_rule table. This change should already be in the main DDL, but this mod script will be available just in case there are old versions of the schema that need to be updated.