### PR TITLE
PC-241: Adding openapi definition for CRUD on retention rules

### DIFF
--- a/scripts/deployment/openapi/openapi.yaml
+++ b/scripts/deployment/openapi/openapi.yaml
@@ -19,7 +19,8 @@ info:
 # The API hostname
 host: your-api.endpoints.your-project.cloud.goog
 x-google-endpoints:
-  - name: SDRS API
+  - # The endpoints name matches the 'host' value above
+    name: your-api.endpoints.your-project.cloud.goog
     # Your target IP Address; Must be quoted
     target: 'your_target_ip'
 paths:


### PR DESCRIPTION
This is viewable in the online swagger editor https://editor.swagger.io/

Some of the endpoints might change in the future, but this is tracking "current" state.
Security definitions will need to be added but are out of scope of the current PR.