### PR TITLE
PC-305 Use Datastorage Branch Import Fix

### DIFF
--- a/src/main/java/com/google/gcs/sdrs/resource/MyResource.java
+++ b/src/main/java/com/google/gcs/sdrs/resource/MyResource.java
@@ -18,29 +18,20 @@
 
 package com.google.gcs.sdrs.resource;
 
-import com.google.gcs.sdrs.JobManager.JobManager;
 import com.google.gcs.sdrs.dao.Dao;
 import com.google.gcs.sdrs.dao.SingletonDao;
 import com.google.gcs.sdrs.dao.model.RetentionJob;
 import com.google.gcs.sdrs.dao.model.RetentionRule;
 import com.google.gcs.sdrs.rule.RuleExecutor;
-import com.google.gcs.sdrs.rule.StsRuleExecutor;
+import com.google.gcs.sdrs.rule.impl.StsRuleExecutor;
 import java.io.IOException;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 
-import com.google.gcs.sdrs.dao.Dao;
-import com.google.gcs.sdrs.dao.SingletonDao;
-import com.google.gcs.sdrs.dao.model.RetentionJob;
-import com.google.gcs.sdrs.dao.model.RetentionRule;
-import com.google.gcs.sdrs.rule.RuleExecutor;
-import com.google.gcs.sdrs.rule.StsRuleExecutor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import java.io.IOException;
 
 /**
  * Root resource (exposed at "myresource" path)
@@ -51,7 +42,6 @@ import java.io.IOException;
 public class MyResource {
 
   static final private Logger logger = LoggerFactory.getLogger(MyResource.class);
-  static final private JobManager jobManager = JobManager.getInstance();
 
   /**
    * Method handling HTTP GET requests. The returned object will be sent


### PR DESCRIPTION
Fixing a file that had old import statements that caused errors after the files were moved. Verified with ```mvn clean install``` on the branch.