### PR TITLE
Session Per Request Refactor

### DIFF
--- a/src/main/java/com/google/gcs/sdrs/dao/BaseDao.java
+++ b/src/main/java/com/google/gcs/sdrs/dao/BaseDao.java
@@ -22,7 +22,6 @@ import com.google.gcs.sdrs.dao.model.RetentionJob;
 import com.google.gcs.sdrs.dao.model.RetentionJobValidation;
 import com.google.gcs.sdrs.dao.model.RetentionRule;
 import java.io.Serializable;
-import java.util.Map;
 import org.hibernate.Session;
 import org.hibernate.SessionFactory;
 import org.hibernate.Transaction;
@@ -51,8 +50,6 @@ public abstract class BaseDao<T, Id extends Serializable> implements Dao<T, Id> 
 
   private static StandardServiceRegistry registry;
   private static SessionFactory sessionFactory;
-  private Session currentSession;
-  private Transaction currentTransaction;
 
   /** A class reference for the entity type */
   protected final Class<T> type;
@@ -62,48 +59,17 @@ public abstract class BaseDao<T, Id extends Serializable> implements Dao<T, Id> 
     this.type = type;
   }
 
-  /** Opens and returns a session */
-  protected Session openCurrentSession() {
-    currentSession = getSessionFactory().openSession();
-    return currentSession;
+  protected Session openSession() {
+    return getSessionFactory().openSession();
   }
 
-  /** Opens and returns a session with a transaction */
-  protected Session openCurrentSessionWithTransaction() {
-    currentSession = getSessionFactory().openSession();
-    currentTransaction = currentSession.beginTransaction();
-    return currentSession;
+  protected void closeSession(Session session) {
+    session.close();
   }
 
-  /** Closes the currently open session */
-  protected void closeCurrentSession() {
-    currentSession.close();
-  }
-
-  /** Commits the current transaction and closes the currently open session */
-  protected void closeCurrentSessionWithTransaction() {
-    currentTransaction.commit();
-    currentSession.close();
-  }
-
-  /** Gets the current session */
-  protected Session getCurrentSession() {
-    return currentSession;
-  }
-
-  /** Sets the current session */
-  protected void setCurrentSession(Session currentSession) {
-    this.currentSession = currentSession;
-  }
-
-  /** Gets the current transaction */
-  protected Transaction getCurrentTransaction() {
-    return currentTransaction;
-  }
-
-  /** Sets the current session */
-  protected void setCurrentTransaction(Transaction currentTransaction) {
-    this.currentTransaction = currentTransaction;
+  protected void closeSessionWithTransaction(Session session, Transaction transaction) {
+    transaction.commit();
+    closeSession(session);
   }
 
   /** Gets the session factory */

--- a/src/main/java/com/google/gcs/sdrs/dao/impl/RetentionJobDaoImpl.java
+++ b/src/main/java/com/google/gcs/sdrs/dao/impl/RetentionJobDaoImpl.java
@@ -1,9 +1,27 @@
+/*
+ * Copyright 2019 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Any software provided by Google hereunder is distributed “AS IS”,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, and is not intended for production use.
+ *
+ */
+
 package com.google.gcs.sdrs.dao.impl;
 
 import com.google.gcs.sdrs.dao.RetentionJobDao;
 import com.google.gcs.sdrs.dao.model.RetentionJob;
+import org.hibernate.Session;
 import org.hibernate.query.Query;
-
 import javax.persistence.criteria.CriteriaBuilder;
 import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Root;
@@ -18,7 +36,8 @@ public class RetentionJobDaoImpl extends GenericDao<RetentionJob, Integer>
 
   @Override
   public List<RetentionJob> findJobsByRuleId(int ruleId) {
-    CriteriaBuilder builder = openCurrentSession().getCriteriaBuilder();
+    Session session = openSession();
+    CriteriaBuilder builder = session.getCriteriaBuilder();
     CriteriaQuery<RetentionJob> criteria = builder.createQuery(RetentionJob.class);
     Root<RetentionJob> root = criteria.from(RetentionJob.class);
 
@@ -26,14 +45,15 @@ public class RetentionJobDaoImpl extends GenericDao<RetentionJob, Integer>
         .select(root)
         .where(builder.equal(root.get("retentionRuleId"), ruleId));
 
-    Query<RetentionJob> query = getCurrentSession().createQuery(criteria);
+    Query<RetentionJob> query = session.createQuery(criteria);
     List<RetentionJob> result = query.getResultList();
-    closeCurrentSession();
+    closeSession(session);
     return result;
   }
 
   public List<RetentionJob> findJobsByRuleIdAndProjectId(int ruleId, String projectId) {
-    CriteriaBuilder builder = openCurrentSession().getCriteriaBuilder();
+    Session session = openSession();
+    CriteriaBuilder builder = session.getCriteriaBuilder();
     CriteriaQuery<RetentionJob> criteria = builder.createQuery(RetentionJob.class);
     Root<RetentionJob> root = criteria.from(RetentionJob.class);
 
@@ -42,9 +62,9 @@ public class RetentionJobDaoImpl extends GenericDao<RetentionJob, Integer>
         .where(builder.equal(root.get("retentionRuleId"), ruleId),
             builder.equal(root.get("retentionRuleProjectId"), projectId));
 
-    Query<RetentionJob> query = getCurrentSession().createQuery(criteria);
+    Query<RetentionJob> query = session.createQuery(criteria);
     List<RetentionJob> result = query.getResultList();
-    closeCurrentSession();
+    closeSession(session);
     return result;
   }
 }

--- a/src/main/java/com/google/gcs/sdrs/dao/impl/RetentionJobValidationDaoImpl.java
+++ b/src/main/java/com/google/gcs/sdrs/dao/impl/RetentionJobValidationDaoImpl.java
@@ -1,3 +1,21 @@
+/*
+ * Copyright 2019 Google LLC. All rights reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the “License”);
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *       http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on an “AS IS” BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and limitations under the License.
+ *
+ * Any software provided by Google hereunder is distributed “AS IS”,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, and is not intended for production use.
+ *
+ */
+
 package com.google.gcs.sdrs.dao.impl;
 
 import com.google.gcs.sdrs.dao.RetentionJobValidationDao;
@@ -16,7 +34,7 @@ import javax.persistence.criteria.CriteriaQuery;
 import javax.persistence.criteria.Join;
 import javax.persistence.criteria.JoinType;
 import javax.persistence.criteria.Root;
-import org.hibernate.query.Query;
+import org.hibernate.Session;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,15 +79,16 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
    * @return a list of RententionJob
    */
   private List<RetentionJob> findAllSingleRunPendingJobs() {
-    CriteriaBuilder builder = openCurrentSession().getCriteriaBuilder();
+    Session session = openSession();
+    CriteriaBuilder builder = session.getCriteriaBuilder();
     CriteriaQuery<RetentionJob> query = builder.createQuery(RetentionJob.class);
     Root<RetentionJob> job = query.from(RetentionJob.class);
     Join<RetentionJob, RetentionJobValidation> jobValidation =
         job.join("jobValidations", JoinType.INNER);
     jobValidation.on(builder.equal(jobValidation.get("status"), RetentionJobStatusType.PENDING));
     query.where(builder.notEqual(job.get("retentionRuleType"), RetentionRuleType.GLOBAL));
-    List<RetentionJob> results = getCurrentSession().createQuery(query).getResultList();
-    closeCurrentSession();
+    List<RetentionJob> results = session.createQuery(query).getResultList();
+    closeSession(session);
     return results;
   }
 
@@ -79,7 +98,8 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
    * @return a list of RententionJob
    */
   private List<RetentionJob> findAllSingleRunJobsWithNoStatus() {
-    CriteriaBuilder builder = openCurrentSession().getCriteriaBuilder();
+    Session session = openSession();
+    CriteriaBuilder builder = session.getCriteriaBuilder();
     CriteriaQuery<RetentionJob> query = builder.createQuery(RetentionJob.class);
     Root<RetentionJob> job = query.from(RetentionJob.class);
     Join<RetentionJob, RetentionJobValidation> jobValidation =
@@ -87,8 +107,8 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
     query.where(
         builder.notEqual(job.get("retentionRuleType"), RetentionRuleType.GLOBAL),
         builder.isNull(jobValidation.get("id")));
-    List<RetentionJob> results = getCurrentSession().createQuery(query).getResultList();
-    closeCurrentSession();
+    List<RetentionJob> results = session.createQuery(query).getResultList();
+    closeSession(session);
     return results;
   }
 
@@ -98,7 +118,8 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
    * @return a list of RententionJob
    */
   private List<RetentionJob> findAllDailyPendingJobs() {
-    CriteriaBuilder builder = openCurrentSession().getCriteriaBuilder();
+    Session session = openSession();
+    CriteriaBuilder builder = session.getCriteriaBuilder();
     CriteriaQuery<RetentionJob> query = builder.createQuery(RetentionJob.class);
     Root<RetentionJob> job = query.from(RetentionJob.class);
     Join<RetentionJob, RetentionJobValidation> jobValidation =
@@ -108,8 +129,8 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
     query.where(
         builder.equal(job.get("retentionRuleType"), RetentionRuleType.GLOBAL),
         builder.greaterThanOrEqualTo(jobValidation.get("updatedAt"), oneDayAgo));
-    List<RetentionJob> results = getCurrentSession().createQuery(query).getResultList();
-    closeCurrentSession();
+    List<RetentionJob> results = session.createQuery(query).getResultList();
+    closeSession(session);
     return results;
   }
 
@@ -119,7 +140,8 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
    * @return a list of RententionJob
    */
   private List<RetentionJob> findAllDailyJobsWithNoStatus() {
-    CriteriaBuilder builder = openCurrentSession().getCriteriaBuilder();
+    Session session = openSession();
+    CriteriaBuilder builder = session.getCriteriaBuilder();
     CriteriaQuery<RetentionJob> query = builder.createQuery(RetentionJob.class);
     Root<RetentionJob> job = query.from(RetentionJob.class);
     Join<RetentionJob, RetentionJobValidation> jobValidation =
@@ -129,8 +151,8 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
     query.where(
         builder.equal(job.get("retentionRuleType"), RetentionRuleType.GLOBAL),
         builder.isNull(jobValidation.get("id")));
-    List<RetentionJob> results = getCurrentSession().createQuery(query).getResultList();
-    closeCurrentSession();
+    List<RetentionJob> results = session.createQuery(query).getResultList();
+    closeSession(session);
     return results;
   }
 
@@ -143,14 +165,15 @@ public class RetentionJobValidationDaoImpl extends GenericDao<RetentionJobValida
    */
   @Override
   public List<RetentionJobValidation> findAllByRetentionJobNames(List<String> retentionJobNames) {
-    CriteriaBuilder builder = openCurrentSession().getCriteriaBuilder();
+    Session session = openSession();
+    CriteriaBuilder builder = session.getCriteriaBuilder();
     CriteriaQuery<RetentionJobValidation> query = builder.createQuery(RetentionJobValidation.class);
     Root<RetentionJobValidation> root = query.from(RetentionJobValidation.class);
 
     query.where(root.get("jobOperationName").in(retentionJobNames));
 
-    List<RetentionJobValidation> results = getCurrentSession().createQuery(query).getResultList();
-    closeCurrentSession();
+    List<RetentionJobValidation> results = session.createQuery(query).getResultList();
+    closeSession(session);
     return results;
   }
 }


### PR DESCRIPTION
Refactoring the DAOs to create and destroy a session per request to avoid multiple requests potentially destroying a session that is actively in use. Also added some legal docs that were missing and cleaned up imports.