### PR TITLE
Added configuration service documentation.

### DIFF
--- a/development-only/readme-configuration.md
+++ b/development-only/readme-configuration.md
@@ -4,15 +4,24 @@
 The API is fully documented in openapi 2.0 (Swagger) format within `/scripts/deployment/openapi/openapi.yaml`
 It can be visually inspected with the Swagger editor available at `https://editor.swagger.io/` 
 
+All responses will include a JSON payload including at least UUID corresponding to that specific request.
+All error responses will include an error message indicating the reason for the error.
+
+A `correlation-uuid` header may be provided. If no value is provided, one will be generated and returned by the server.
+
+### Authentication
+Operations are authenticated with JWTs included as a request header, like:
+`Authorization: Bearer <token>`. 
+
+
 ### Retention Rules
 CRUD operations are supported on Retention Rules.
-Successful operations will return a 200 response with a JSON payload.
 
 ---
 
 #### Create Retention Rule: `POST /retentionrules`
 ##### Fields and Validation
-Body Params:
+JSON Body Params:
 
 `type`: A string matching either `GLOBAL` or `DATASET`. `DATASET` rules require a `projectId` and `dataStorageName`. 
 
@@ -52,7 +61,7 @@ Query Params:
 
 #### Update Retention Rule: `PUT /retentionrules/{ruleId}`
 ##### Fields and Validation
-Body Params:
+JSON Body Params:
 
 `ruleId`: A number indicating the id of the rule to update. 
 


### PR DESCRIPTION
Most of this is covered under the openapi yaml file, so I'm attempting to use this as a chance to further document the field validations and what status codes belong to which error messages.