### PR TITLE
Fixed issue where unit test was dependent on configuration value

### DIFF
--- a/src/main/java/com/google/gcs/sdrs/util/SdrsRequestClientUtil.java
+++ b/src/main/java/com/google/gcs/sdrs/util/SdrsRequestClientUtil.java
@@ -41,10 +41,10 @@ import org.slf4j.LoggerFactory;
 public class SdrsRequestClientUtil {
 
   private static final Logger logger = LoggerFactory.getLogger(SdrsRequestClientUtil.class);
-  private static String serviceUrl;
-  private static String protocol;
+  static String serviceUrl;
+  static String protocol;
   private static String apiKey;
-  private static String port;
+  static String port;
 
   static CredentialsUtil credentialsUtil = CredentialsUtil.getInstance();
 

--- a/src/test/java/com/google/gcs/sdrs/util/SdrsRequestClientUtilTest.java
+++ b/src/test/java/com/google/gcs/sdrs/util/SdrsRequestClientUtilTest.java
@@ -21,10 +21,8 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.googleapis.testing.auth.oauth2.MockGoogleCredential;
 import java.io.IOException;
 import java.math.BigInteger;
-import java.nio.ByteBuffer;
 import java.security.InvalidKeyException;
 import java.security.interfaces.RSAPrivateKey;
-import java.util.Arrays;
 import java.util.Random;
 import javax.ws.rs.client.Client;
 import javax.ws.rs.client.Invocation;
@@ -48,7 +46,7 @@ public class SdrsRequestClientUtilTest {
   private WebTarget webTarget;
 
   @Before
-  public void setup() throws IOException, InvalidKeyException {
+  public void setup() throws IOException {
     client = mock(Client.class, Mockito.RETURNS_DEEP_STUBS);
     builder = mock(Invocation.Builder.class);
     webTarget = mock(WebTarget.class);
@@ -83,9 +81,13 @@ public class SdrsRequestClientUtilTest {
 
   @Test
   public void usesConfiguredProtocolAndServiceUrl() {
+    SdrsRequestClientUtil.serviceUrl = "url";
+    SdrsRequestClientUtil.protocol = "http";
+    SdrsRequestClientUtil.port = "80";
+
     SdrsRequestClientUtil.request(client, "something").post(null);
 
-    verify(client).target(eq("http://localhost:80"));
+    verify(client).target(eq("http://url:80"));
   }
 
   @Test


### PR DESCRIPTION
There's not currently a terrific way to mock config values, so I'm making them package private.