### PR TITLE
Set transfer option properly for updating default STS job.

### DIFF
--- a/src/main/java/com/google/gcs/sdrs/service/worker/rule/impl/StsRuleExecutor.java
+++ b/src/main/java/com/google/gcs/sdrs/service/worker/rule/impl/StsRuleExecutor.java
@@ -22,6 +22,7 @@ import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.services.storagetransfer.v1.Storagetransfer;
 import com.google.api.services.storagetransfer.v1.model.ObjectConditions;
 import com.google.api.services.storagetransfer.v1.model.TransferJob;
+import com.google.api.services.storagetransfer.v1.model.TransferOptions;
 import com.google.api.services.storagetransfer.v1.model.TransferSpec;
 import com.google.gcs.sdrs.SdrsApplication;
 import com.google.gcs.sdrs.common.RetentionRuleType;
@@ -444,6 +445,12 @@ public class StsRuleExecutor implements RuleExecutor {
       objectConditions = new ObjectConditions();
       transferSpec.setObjectConditions(objectConditions);
     }
+
+    // make sure transfer options are set properly
+    transferSpec.setTransferOptions(
+        new TransferOptions()
+            .setDeleteObjectsFromSourceAfterTransfer(true)
+            .setOverwriteObjectsAlreadyExistingInSink(true));
 
     boolean retentionPeriodChanged = false;
     boolean prefixesToExcludeChanged = false;


### PR DESCRIPTION
Minor bug fix. Make sure that the transfer options are set properly when updating default STS job. The correct options are:
1) Delete object from the source after transfer
2) Overwrite objects if already exist in destination