### PR TITLE
Set createdAt using the lastModifedTime from the updated STS job

### DIFF
--- a/src/main/java/com/google/gcs/sdrs/dao/model/RetentionJob.java
+++ b/src/main/java/com/google/gcs/sdrs/dao/model/RetentionJob.java
@@ -135,6 +135,10 @@ public class RetentionJob {
     return createdAt;
   }
 
+  public void setCreatedAt(Timestamp createdAt) {
+    this.createdAt = createdAt;
+  }
+
   public Timestamp getUpdatedAt() {
     return updatedAt;
   }

--- a/src/test/java/com/google/gcs/sdrs/service/worker/rule/impl/StsRuleExecutorTest.java
+++ b/src/test/java/com/google/gcs/sdrs/service/worker/rule/impl/StsRuleExecutorTest.java
@@ -90,7 +90,7 @@ public class StsRuleExecutorTest {
   public void buildRetentionJobTest() {
     String jobName = "test";
 
-    RetentionJob result = objectUnderTest.buildRetentionJobEntity(jobName, testRule, null);
+    RetentionJob result = objectUnderTest.buildRetentionJobEntity(jobName, testRule, null, null);
 
     assertEquals(result.getName(), jobName);
     assertEquals((int) result.getRetentionRuleId(), (int) testRule.getId());


### PR DESCRIPTION
There is a clock difference between Cloud SQL and STS. Instead of using now() for retention_job.createdAt field from the Cloud SQL, actively setting it from the lastModifledTime of the updated STS job. 