### PR TITLE
Pass in projectId when creating gcs client

### DIFF
--- a/src/main/java/com/google/gcs/sdrs/controller/EventsController.java
+++ b/src/main/java/com/google/gcs/sdrs/controller/EventsController.java
@@ -188,7 +188,7 @@ public class EventsController extends BaseController {
                       target)));
         } else {
           String bucketName = RetentionUtil.getBucketName(target);
-          if (!GcsHelper.getInstance().doesBucketExist(bucketName, projectId)) {
+          if (!GcsHelper.getInstance(projectId).doesBucketExist(bucketName, projectId)) {
             validations.add(
                 ValidationResult.fromString(
                     String.format("The bucket %s/%s does not exist", projectId, bucketName)));

--- a/src/main/java/com/google/gcs/sdrs/service/impl/RetentionRulesServiceImpl.java
+++ b/src/main/java/com/google/gcs/sdrs/service/impl/RetentionRulesServiceImpl.java
@@ -75,7 +75,7 @@ public class RetentionRulesServiceImpl implements RetentionRulesService {
       throws SQLException, IOException {
     String bucketName = RetentionUtil.getBucketName(rule.getDataStorageName());
     if (rule.getRetentionRuleType() != RetentionRuleType.GLOBAL) {
-      if (!GcsHelper.getInstance().doesBucketExist(bucketName, rule.getProjectId())) {
+      if (!GcsHelper.getInstance(rule.getProjectId()).doesBucketExist(bucketName, rule.getProjectId())) {
         throw new IOException(
             String.format("Bucket %s does not exist for project %s", bucketName, rule.getProjectId()));
       }

--- a/src/main/java/com/google/gcs/sdrs/service/worker/rule/impl/StsRuleExecutor.java
+++ b/src/main/java/com/google/gcs/sdrs/service/worker/rule/impl/StsRuleExecutor.java
@@ -204,7 +204,7 @@ public class StsRuleExecutor implements RuleExecutor {
 
         if (retentionValue.getUnitType() == RetentionUnitType.VERSION) {
           String prefix = RetentionUtil.generateValidPrefixForListingObjects(datasetPath);
-          List<String> objectsPath = GcsHelper.getInstance().listObjectsWithPrefixInBucket(
+          List<String> objectsPath = GcsHelper.getInstance(datasetRule.getProjectId()).listObjectsWithPrefixInBucket(
               bucketName, prefix);
           tmpPrefixes = PrefixGeneratorUtility.generateVersionPrefix(objectsPath,
               retentionValue.getNumber());

--- a/src/test/java/com/google/gcs/sdrs/controller/EventsControllerTest.java
+++ b/src/test/java/com/google/gcs/sdrs/controller/EventsControllerTest.java
@@ -61,7 +61,7 @@ public class EventsControllerTest {
     mockDmQueueDao = mock(DmQueueDao.class);
 
     PowerMockito.mockStatic(GcsHelper.class);
-    when(GcsHelper.getInstance()).thenReturn(mockGcsHelper);
+    when(GcsHelper.getInstance(any())).thenReturn(mockGcsHelper);
 
     PowerMockito.mockStatic(SingletonDao.class);
     when(SingletonDao.getDmQueueDao()).thenReturn(mockDmQueueDao);

--- a/src/test/java/com/google/gcs/sdrs/service/impl/RetentionRulesServiceImplTest.java
+++ b/src/test/java/com/google/gcs/sdrs/service/impl/RetentionRulesServiceImplTest.java
@@ -79,7 +79,7 @@ public class RetentionRulesServiceImplTest {
     when(StsRuleExecutor.getInstance()).thenReturn(null);
 
     PowerMockito.mockStatic(GcsHelper.class);
-    when(GcsHelper.getInstance()).thenReturn(mockGcsHelper);
+    when(GcsHelper.getInstance(any())).thenReturn(mockGcsHelper);
     when(mockGcsHelper.doesBucketExist(any(), any())).thenReturn(true);
   }
 


### PR DESCRIPTION
In currently workflow, when creating GCS client, it uses the default one 
`storage = StorageOptions.getDefaultInstance().getService();` 
It works before when SDRS running on the VMs for each project. Because the bucket sits in the same project.
After moving SDRS to GKE, it will direct to the project where GKE instance is running when creating GCS client which is different from the project where the bucket exists. This causes some of the functionalities not working like creating retention policy and event execution.  

I made the change to the GCSHelper function to pass in the projectId while creating GCS client. It's been tested in GKE and worked. 